### PR TITLE
Add general after_commit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Fixed README (Thomas Brus / thomasbrus)
+* Added `:after_commit` / `:<model_name>_committed` events (Ryan Platte
+  / replaid) 
 
 ## 0.2.0 (21 Oct 2014)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Please refer to the [Wisper README](https://github.com/krisleech/wisper) for ful
 The events which are automatically broadcast are:
 
 * `after_create`
-* `after_create`
 * `after_destroy`
 * `create_<model_name>_{successful, failed}`
 * `update_<model_name>_{successful, failed}`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The events which are automatically broadcast are:
 * `create_<model_name>_{successful, failed}`
 * `update_<model_name>_{successful, failed}`
 * `destroy_<model_name>_successful`
+* `<model_name>_committed`
+* `after_commit`
 * `after_rollback`
 
 ### Reacting to Events

--- a/lib/wisper/active_record/publisher.rb
+++ b/lib/wisper/active_record/publisher.rb
@@ -10,6 +10,7 @@ module Wisper
         after_commit     :after_create_broadcast,  on: :create
         after_commit     :after_update_broadcast,  on: :update
         after_commit     :after_destroy_broadcast, on: :destroy
+        after_commit     :after_commit_broadcast
         after_rollback   :after_rollback_broadcast
       end
 
@@ -30,26 +31,40 @@ module Wisper
 
       def after_validation_broadcast
         action = new_record? ? 'create' : 'update'
-        broadcast("#{action}_#{self.class.model_name.param_key}_failed", self) unless errors.empty?
+        broadcast("#{action}_#{broadcast_model_name_key}_failed", self) unless errors.empty?
       end
 
       def after_create_broadcast
         broadcast(:after_create, self)
-        broadcast("create_#{self.class.model_name.param_key}_successful", self)
+        broadcast("create_#{broadcast_model_name_key}_successful", self)
       end
 
       def after_update_broadcast
         broadcast(:after_update, self)
-        broadcast("update_#{self.class.model_name.param_key}_successful", self)
+        broadcast("update_#{broadcast_model_name_key}_successful", self)
       end
 
       def after_destroy_broadcast
         broadcast(:after_destroy, self)
-        broadcast("destroy_#{self.class.model_name.param_key}_successful", self)
+        broadcast("destroy_#{broadcast_model_name_key}_successful", self)
+      end
+
+      def after_commit_broadcast
+        broadcast(:after_commit, self)
+        broadcast("#{broadcast_model_name_key}_committed", self)
+      end
+
+      def after_commit_broadcast
+        broadcast(:after_commit, self)
+        broadcast("#{broadcast_model_name_key}_committed", self)
       end
 
       def after_rollback_broadcast
         broadcast(:after_rollback, self)
+      end
+
+      def broadcast_model_name_key
+        self.class.model_name.param_key
       end
     end
   end

--- a/spec/wisper/activerecord_spec.rb
+++ b/spec/wisper/activerecord_spec.rb
@@ -83,6 +83,21 @@ describe 'ActiveRecord' do
     end
   end
 
+  describe 'commit' do
+    after do
+      model_class.subscribe(listener)
+      model_class.create
+    end
+
+    it 'publishes an after_commit event to listener' do
+      expect(listener).to receive(:after_commit).with(instance_of(model_class))
+    end
+
+    it 'publishes a <model_name>_committed event to listener' do
+      expect(listener).to receive(:meeting_committed).with(instance_of(model_class))
+    end
+  end
+
   describe 'rollback' do
     it 'publishes an after_rollback event to listener' do
       expect(listener).to receive(:after_rollback).with(instance_of(model_class))

--- a/spec/wisper/activerecord_spec.rb
+++ b/spec/wisper/activerecord_spec.rb
@@ -76,10 +76,21 @@ describe 'ActiveRecord' do
 
     let(:model) { model_class.first }
 
-    it 'publishes an on_destroy event to listener' do
+    it 'publishes an after_destroy event to listener' do
       expect(listener).to receive(:after_destroy).with(instance_of(model_class))
       model_class.subscribe(listener)
       model.destroy
+    end
+  end
+
+  describe 'rollback' do
+    it 'publishes an after_rollback event to listener' do
+      expect(listener).to receive(:after_rollback).with(instance_of(model_class))
+      model_class.subscribe(listener)
+      model_class.transaction do
+        model_class.create!
+        raise ActiveRecord::Rollback
+      end
     end
   end
 end


### PR DESCRIPTION
I have use for a general `after_commit` / `<model name>_committed` event; without it I'll be writing listeners for all the other commit events.

If this is undesirable for some reason, please see the other commits for improvements to the specs.