### PR TITLE
Add after_update to list of events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Please refer to the [Wisper README](https://github.com/krisleech/wisper) for ful
 The events which are automatically broadcast are:
 
 * `after_create`
+* `after_update`
 * `after_destroy`
 * `create_<model_name>_{successful, failed}`
 * `update_<model_name>_{successful, failed}`


### PR DESCRIPTION
`after_update` is missing from the README and someone may think this event is not available to listen to.